### PR TITLE
Add transcription script with OpenAI integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Python Codespace",
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+  "features": {},
+  "postCreateCommand": "pip install -r requirements.txt"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environment
+venv/
+
+# Environment variables
+.env
+
+# Audio chunks
+*part*.mp3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# transcribe
+# TechJoint Transcription
+
+This repository provides a Python script for transcribing large audio files with OpenAI. The audio is automatically split into five-minute chunks before each chunk is sent to the OpenAI API for transcription. The final output is the combined text from all chunks.
+
+## Getting Started in GitHub Codespaces
+
+1. **Create a Codespace** – In GitHub, choose **Code → Codespaces → Create codespace on main**.
+2. Dependencies are installed automatically by the `postCreateCommand` in `.devcontainer/devcontainer.json`.
+3. Add a `.env` file in the project root with your OpenAI API key:
+   ```bash
+   echo "OPENAI_API_KEY=YOUR_KEY_HERE" > .env
+   ```
+   The `.env` file is ignored by Git, so your key remains private.
+4. From the terminal, run the transcription script:
+   ```bash
+   python transcribe.py path/to/audio.mp3 -o output.txt
+   ```
+   Replace `path/to/audio.mp3` with your file. The optional `-o` flag writes the result to `output.txt`.
+
+## Security Notes
+
+- Keep your API key inside the `.env` file and **never** commit it.
+- Temporary audio chunks are deleted after transcription.
+- Review OpenAI's data policies to ensure your usage complies with their terms.
+
+## Requirements
+
+- Python 3.10+
+- `ffmpeg` installed (required by `pydub`)
+
+All Python dependencies are listed in `requirements.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.14
+pydub>=0.25
+python-dotenv>=1.0

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Transcribe audio files in 5-minute chunks using OpenAI."""
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from pydub import AudioSegment
+import openai
+
+CHUNK_MS = 5 * 60 * 1000  # 5 minutes in milliseconds
+
+
+def split_audio(audio: AudioSegment) -> list[AudioSegment]:
+    """Split AudioSegment into 5-minute chunks."""
+    return [audio[i : i + CHUNK_MS] for i in range(0, len(audio), CHUNK_MS)]
+
+
+def transcribe_segment(segment: AudioSegment, idx: int, base: Path, model: str, language: str | None) -> str:
+    """Export the segment to a temporary file and transcribe it."""
+    temp_file = base.with_name(f"{base.stem}_part{idx}.mp3")
+    segment.export(temp_file, format="mp3")
+    try:
+        with open(temp_file, "rb") as f:
+            response = openai.Audio.transcribe(model=model, file=f, language=language)
+        return response["text"]
+    finally:
+        temp_file.unlink(missing_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Transcribe an audio file with OpenAI in 5-minute chunks."
+    )
+    parser.add_argument("input", type=Path, help="Path to the audio file")
+    parser.add_argument("-o", "--output", type=Path, help="File to save the transcription")
+    parser.add_argument(
+        "-l",
+        "--language",
+        type=str,
+        default=None,
+        help="Optional language code, e.g. 'en'",
+    )
+    parser.add_argument(
+        "-m", "--model", type=str, default="whisper-1", help="OpenAI transcription model"
+    )
+    args = parser.parse_args()
+
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit(
+            "OPENAI_API_KEY not set. Add it to a .env file in this directory."
+        )
+    openai.api_key = api_key
+
+    audio = AudioSegment.from_file(args.input)
+    chunks = split_audio(audio)
+    base = args.input
+
+    texts = []
+    for idx, chunk in enumerate(chunks):
+        texts.append(transcribe_segment(chunk, idx, base, args.model, args.language))
+
+    result = "\n".join(texts)
+    if args.output:
+        args.output.write_text(result)
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up devcontainer with Python 3.10 image and install requirements automatically
- ignore temporary and secret files via `.gitignore`
- document how to run transcription in Codespaces and where to place the API key
- list required packages in `requirements.txt`
- implement `transcribe.py` to split audio into five‑minute chunks and send each to OpenAI for transcription

## Testing
- `python -m py_compile transcribe.py`
