### PR TITLE
Add Flask Whisper transcription web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# transcribe
+# Transcribe
+
+A simple Flask web application for transcribing audio or video files using OpenAI's Whisper API. The app logs basic request information and errors to the console.
+
+## Setup
+
+1. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Set your OpenAI API key in the environment:
+   ```bash
+   export OPENAI_API_KEY=your_key_here
+   ```
+   Or create a `.env` file with the line:
+   ```bash
+   OPENAI_API_KEY=your_key_here
+   ```
+4. Run the application:
+   ```bash
+   flask run
+   ```
+   The app will be available at `http://127.0.0.1:5000`.
+
+## Usage
+
+1. Navigate to the homepage.
+2. Upload an audio or video file (`.mp3`, `.wav`, `.m4a`, `.mp4`, `.mov`, etc.).
+3. The transcript will be displayed and can be downloaded as a `.txt` file.
+   Uploaded files are limited to 100 MB.
+
+## Notes
+
+This project requires network access to communicate with OpenAI's API when transcribing files. The application logs basic request information and errors to the console at INFO level.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import tempfile
+import logging
+from flask import Flask, request, render_template, send_file
+from dotenv import load_dotenv
+from werkzeug.utils import secure_filename
+from werkzeug.exceptions import RequestEntityTooLarge
+import openai
+
+load_dotenv()
+
+# Initialize OpenAI with API key from environment
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+app = Flask(__name__)
+# Limit uploads to 100 MB
+app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024
+
+# Basic logging to stdout
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stdout,
+    format='%(asctime)s %(levelname)s: %(message)s'
+)
+app.logger.setLevel(logging.INFO)
+
+# Allowed file extensions for uploads
+ALLOWED_EXTENSIONS = {"mp3", "wav", "m4a", "mp4", "mov"}
+
+# In-memory store for generated transcript files
+transcripts = {}
+
+def allowed_file(filename: str) -> bool:
+    """Check if a filename has an allowed extension."""
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.before_request
+def log_request_info():
+    """Log basic request info."""
+    app.logger.info("%s %s", request.method, request.path)
+
+@app.route("/")
+def index():
+    """Render the upload form."""
+    return render_template("index.html")
+
+@app.route("/transcribe", methods=["POST"])
+def transcribe():
+    """Handle file upload and send to OpenAI for transcription."""
+    upload = request.files.get("file")
+    if not upload or upload.filename == "":
+        return render_template("index.html", error="No file selected")
+    if not allowed_file(upload.filename):
+        return render_template("index.html", error="Unsupported file type")
+
+    try:
+        # Save upload to a temporary file for sending to the API
+        filename = secure_filename(upload.filename)
+        suffix = os.path.splitext(filename)[1]
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            upload.save(tmp.name)
+            tmp.seek(0)
+            response = openai.audio.transcriptions.create(
+                model="whisper-1",
+                file=open(tmp.name, "rb")
+            )
+
+        # Extract transcript text from response
+        transcript = response.get("text") if isinstance(response, dict) else getattr(response, "text", "")
+
+        # Store transcript in a temp file for download
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt", mode="w", encoding="utf-8") as tfile:
+            tfile.write(transcript)
+            transcript_path = tfile.name
+
+        token = os.path.basename(transcript_path)
+        transcripts[token] = transcript_path
+
+        return render_template("result.html", transcript=transcript, filename=token)
+    except Exception as exc:
+        # Show the error message to the user
+        app.logger.error("Error during transcription: %s", exc)
+        return render_template("index.html", error=str(exc))
+    finally:
+        # Clean up upload temporary file
+        try:
+            os.unlink(tmp.name)
+        except Exception:
+            pass
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def handle_large_file(error):
+    """Return friendly message when file is too big."""
+    app.logger.error("Uploaded file too large")
+    return render_template("index.html", error="File too large (limit 100 MB)"), 413
+
+@app.route("/download")
+def download():
+    """Serve the transcript text file for download."""
+    token = request.args.get("filename")
+    path = transcripts.get(token)
+    if not path or not os.path.exists(path):
+        return render_template("index.html", error="Transcript not found")
+    return send_file(path, as_attachment=True, download_name="transcript.txt")
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+python-dotenv
+openai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Transcribe Audio/Video</title>
+</head>
+<body>
+    <h1>Upload Audio or Video for Transcription</h1>
+    <form action="/transcribe" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept=".mp3,.wav,.m4a,.mp4,.mov" required>
+        <button type="submit">Upload and Transcribe</button>
+    </form>
+    <p>Maximum file size: 100 MB</p>
+    {% if error %}
+        <p style="color:red;">{{ error }}</p>
+    {% endif %}
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Transcription Result</title>
+</head>
+<body>
+    <h1>Transcription</h1>
+    <pre>{{ transcript }}</pre>
+    <a href="/download?filename={{ filename }}">Download as .txt</a>
+    <br>
+    <a href="/">Transcribe another file</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Flask app to upload files, send to OpenAI Whisper API, and serve transcript
- add HTML templates for upload and result pages
- provide requirements.txt and README instructions
- improve security with secure_filename, limit uploads to 100 MB
- add logging and friendly error handling

## Testing
- `python3 -m py_compile app.py`
