### PR TITLE
Add large-file chunked transcription with gpt-4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# transcribe
+# Transcribe
+
+A Flask web application that sends audio or video uploads to OpenAI's `gpt-4o-transcribe` model. Large files are automatically split into five‑minute pieces and processed one by one with progress feedback.
+
+## Setup
+
+1. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   `pydub` and `moviepy` require `ffmpeg` to be installed on your system.
+3. Set your OpenAI API key in the environment:
+   ```bash
+   export OPENAI_API_KEY=your_key_here
+   ```
+   Or create a `.env` file with the line:
+   ```bash
+   OPENAI_API_KEY=your_key_here
+   ```
+4. Run the application:
+   ```bash
+   flask run
+   ```
+   The app will be available at `http://127.0.0.1:5000`.
+
+## Usage
+
+1. Navigate to the homepage.
+2. Upload an audio or video file (`.mp3`, `.wav`, `.m4a`, `.mp4`, `.mov`, etc.). Files of any size are supported.
+3. A progress page appears while the file is chunked and transcribed.
+4. When finished, the full transcript is displayed and can be downloaded as `transcript.txt`.
+
+## Notes
+
+Basic request information and any processing errors are logged to stdout. Network access is required to communicate with OpenAI's API when transcribing files.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,127 @@
+import os
+import uuid
+import tempfile
+import threading
+import logging
+from flask import Flask, request, render_template, send_file, jsonify
+from werkzeug.utils import secure_filename
+from dotenv import load_dotenv
+from pydub import AudioSegment
+import openai
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+app = Flask(__name__)
+
+# Allowed file extensions
+ALLOWED_EXTENSIONS = {"mp3", "wav", "m4a", "mp4", "mov"}
+
+# Store job progress and results
+jobs = {}
+
+logging.basicConfig(level=logging.INFO)
+
+@app.before_request
+def log_request():
+    app.logger.info("%s %s", request.method, request.path)
+
+
+def allowed_file(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/transcribe", methods=["POST"])
+def transcribe():
+    upload = request.files.get("file")
+    if not upload or upload.filename == "":
+        return render_template("index.html", error="No file selected")
+    if not allowed_file(upload.filename):
+        return render_template("index.html", error="Unsupported file type")
+
+    filename = secure_filename(upload.filename)
+    tmpdir = tempfile.mkdtemp()
+    filepath = os.path.join(tmpdir, filename)
+    upload.save(filepath)
+
+    job_id = str(uuid.uuid4())
+    jobs[job_id] = {"status": "processing", "progress": 0.0}
+    thread = threading.Thread(target=process_file, args=(job_id, filepath, tmpdir))
+    thread.start()
+
+    return render_template("progress.html", job_id=job_id)
+
+
+def process_file(job_id: str, path: str, tmpdir: str):
+    try:
+        audio = AudioSegment.from_file(path)
+        chunk_ms = 5 * 60 * 1000  # five minutes
+        total_chunks = (len(audio) + chunk_ms - 1) // chunk_ms
+        parts = []
+        for i, start in enumerate(range(0, len(audio), chunk_ms)):
+            chunk = audio[start:start + chunk_ms]
+            chunk_path = os.path.join(tmpdir, f"chunk_{i}.mp3")
+            chunk.export(chunk_path, format="mp3")
+            with open(chunk_path, "rb") as cfile:
+                resp = openai.audio.transcriptions.create(
+                    model="gpt-4o-transcribe",
+                    file=cfile
+                )
+            text = resp.get("text") if isinstance(resp, dict) else getattr(resp, "text", "")
+            parts.append(text)
+            jobs[job_id]["progress"] = (i + 1) / total_chunks
+        transcript = "\n".join(parts)
+        tpath = os.path.join(tmpdir, "transcript.txt")
+        with open(tpath, "w", encoding="utf-8") as tfile:
+            tfile.write(transcript)
+        jobs[job_id].update({"status": "done", "transcript": transcript, "tpath": tpath})
+    except Exception as exc:
+        jobs[job_id].update({"status": "error", "error": str(exc)})
+        app.logger.exception("Error processing job %s", job_id)
+    finally:
+        try:
+            os.remove(path)
+        except Exception:
+            pass
+
+
+@app.route("/progress/<job_id>")
+def progress(job_id):
+    if job_id not in jobs:
+        return render_template("index.html", error="Job not found")
+    return render_template("progress.html", job_id=job_id)
+
+
+@app.route("/progress_status/<job_id>")
+def progress_status(job_id):
+    job = jobs.get(job_id)
+    if not job:
+        return jsonify({"status": "error", "error": "Job not found"})
+    return jsonify(job)
+
+
+@app.route("/result/<job_id>")
+def result(job_id):
+    job = jobs.get(job_id)
+    if not job:
+        return render_template("index.html", error="Job not found")
+    if job.get("status") != "done":
+        return render_template("progress.html", job_id=job_id)
+    return render_template("result.html", transcript=job.get("transcript"), job_id=job_id)
+
+
+@app.route("/download/<job_id>")
+def download(job_id):
+    job = jobs.get(job_id)
+    if not job or job.get("status") != "done":
+        return render_template("index.html", error="Transcript not available")
+    return send_file(job["tpath"], as_attachment=True, download_name="transcript.txt")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+python-dotenv
+openai
+pydub
+moviepy

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Transcribe Audio/Video</title>
+</head>
+<body>
+    <h1>Upload Audio or Video for Transcription</h1>
+    <form action="/transcribe" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept=".mp3,.wav,.m4a,.mp4,.mov" required>
+        <button type="submit">Upload and Transcribe</button>
+    </form>
+    <p>Files are automatically split into 5-minute chunks for processing.</p>
+    {% if error %}
+        <p style="color:red;">{{ error }}</p>
+    {% endif %}
+</body>
+</html>

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Processing...</title>
+    <script>
+    function poll() {
+        fetch('/progress_status/{{ job_id }}')
+        .then(r => r.json())
+        .then(data => {
+            if (data.status === 'done') {
+                window.location.href = '/result/{{ job_id }}';
+            } else if (data.status === 'error') {
+                document.getElementById('msg').innerText = data.error;
+            } else {
+                const pct = Math.round((data.progress || 0) * 100);
+                document.getElementById('msg').innerText = 'Processing... ' + pct + '%';
+                setTimeout(poll, 1000);
+            }
+        });
+    }
+    window.onload = poll;
+    </script>
+</head>
+<body>
+    <p id="msg">Starting...</p>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Transcription Result</title>
+</head>
+<body>
+    <h1>Transcription</h1>
+    <pre>{{ transcript }}</pre>
+    <a href="/download/{{ job_id }}">Download as .txt</a>
+    <br>
+    <a href="/">Transcribe another file</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split uploaded files into five‑minute chunks and transcribe each with the `gpt-4o-transcribe` model
- show a progress page while background transcription runs
- log requests, save transcripts, and allow download
- document chunking behaviour and new dependencies

## Testing
- `python3 -m py_compile app.py`
