### PR TITLE
Add chunked transcription with progress and gpt-4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# transcribe
+# Transcribe
+
+A Flask web application that sends audio or video uploads to OpenAI's `gpt-4o-transcribe` model. Large files are automatically split into five-minute pieces and processed one by one with progress feedback.
+
+## Setup
+
+1. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   `pydub` and `moviepy` require `ffmpeg` to be installed on your system.
+3. Set your OpenAI API key in the environment:
+   ```bash
+   export OPENAI_API_KEY=your_key_here
+   ```
+   Or create a `.env` file with the line:
+   ```bash
+   OPENAI_API_KEY=your_key_here
+   ```
+4. Run the application:
+   ```bash
+   flask run
+   ```
+   The app will be available at `http://127.0.0.1:5000`.
+
+## Usage
+
+1. Navigate to the homepage.
+2. Upload an audio or video file (`.mp3`, `.wav`, `.m4a`, `.mp4`, `.mov`, etc.). Files of any size are supported. Large files are automatically split into 5-minute chunks and processed one by one. A progress page will show the current percentage.
+3. When processing is complete, the transcript will be displayed and can be downloaded as a `.txt` file.
+
+## Notes
+
+Basic request information and any processing errors are logged to stdout. This project requires network access to communicate with OpenAI's API when transcribing files. MoviePy relies on `ffmpeg` being available on your system.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,170 @@
+import os
+import tempfile
+import uuid
+import threading
+import logging
+from flask import Flask, request, render_template, send_file, jsonify
+from dotenv import load_dotenv
+from werkzeug.utils import secure_filename
+import openai
+from moviepy.editor import AudioFileClip, VideoFileClip
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+logger = logging.getLogger(__name__)
+
+# Initialize OpenAI with API key from environment
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+app = Flask(__name__)
+
+# Track async transcription tasks
+tasks = {}
+
+# Allowed file extensions for uploads
+ALLOWED_EXTENSIONS = {"mp3", "wav", "m4a", "mp4", "mov"}
+
+# In-memory store for generated transcript files
+transcripts = {}
+
+
+def split_into_chunks(path: str) -> list:
+    """Split an audio/video file into 5-minute chunks and return a list of paths."""
+    chunks = []
+    audio_clip = None
+    video_clip = None
+    try:
+        try:
+            audio_clip = AudioFileClip(path)
+        except Exception:
+            video_clip = VideoFileClip(path)
+            audio_clip = video_clip.audio
+
+        duration = int(audio_clip.duration)
+        for start in range(0, duration, 300):
+            end = min(start + 300, duration)
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+            audio_clip.subclip(start, end).write_audiofile(tmp.name, logger=None)
+            chunks.append(tmp.name)
+    finally:
+        if audio_clip:
+            audio_clip.close()
+        if video_clip:
+            video_clip.close()
+    return chunks
+
+
+def process_task(token: str):
+    """Background worker to transcribe uploaded file."""
+    info = tasks[token]
+    path = info["file"]
+    try:
+        chunks = split_into_chunks(path)
+        total = len(chunks)
+        transcript_parts = []
+        for i, chunk_path in enumerate(chunks, start=1):
+            tasks[token]["progress"] = int((i - 1) / total * 100)
+            tasks[token]["status"] = f"Transcribing chunk {i} of {total}"
+            with open(chunk_path, "rb") as f:
+                resp = openai.audio.transcriptions.create(model="gpt-4o-transcribe", file=f)
+            text = resp.get("text") if isinstance(resp, dict) else getattr(resp, "text", "")
+            transcript_parts.append(text)
+            os.unlink(chunk_path)
+
+        full_text = "\n".join(transcript_parts)
+        info["progress"] = 100
+        info["status"] = "done"
+        info["transcript"] = full_text
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt", mode="w", encoding="utf-8") as tfile:
+            tfile.write(full_text)
+            transcripts[token] = tfile.name
+    except Exception as exc:
+        info["status"] = "error"
+        info["error"] = str(exc)
+        logger.exception("Error processing file: %s", exc)
+    finally:
+        try:
+            os.unlink(path)
+        except Exception:
+            pass
+
+def allowed_file(filename: str) -> bool:
+    """Check if a filename has an allowed extension."""
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.before_request
+def log_request_info():
+    logger.info("%s %s", request.method, request.path)
+
+
+@app.route("/")
+def index():
+    """Render the upload form."""
+    return render_template("index.html")
+
+
+@app.route("/transcribe", methods=["POST"])
+def transcribe():
+    """Handle file upload and start background transcription."""
+    upload = request.files.get("file")
+    if not upload or upload.filename == "":
+        return render_template("index.html", error="No file selected")
+    if not allowed_file(upload.filename):
+        return render_template("index.html", error="Unsupported file type")
+
+    filename = secure_filename(upload.filename)
+
+    # Save upload to a temporary file
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(filename)[1])
+    upload.save(tmp.name)
+
+    token = uuid.uuid4().hex
+    tasks[token] = {"progress": 0, "status": "queued", "file": tmp.name}
+
+    thread = threading.Thread(target=process_task, args=(token,))
+    thread.daemon = True
+    thread.start()
+
+    return render_template("progress.html", task_id=token)
+
+
+@app.route("/progress")
+def progress():
+    """Return JSON progress for a given task."""
+    token = request.args.get("task_id")
+    info = tasks.get(token)
+    if not info:
+        return jsonify({"status": "unknown", "progress": 0})
+    return jsonify({"status": info.get("status"), "progress": info.get("progress", 0)})
+
+
+@app.route("/result")
+def result():
+    """Show the final transcript."""
+    token = request.args.get("task_id")
+    info = tasks.get(token)
+    if not info:
+        return render_template("index.html", error="Invalid task")
+    if info.get("status") != "done":
+        error = info.get("error", "Transcription not complete")
+        return render_template("index.html", error=error)
+
+    transcript = info.get("transcript", "")
+    return render_template("result.html", transcript=transcript, filename=token)
+
+
+@app.route("/download")
+def download():
+    """Serve the transcript text file for download."""
+    token = request.args.get("filename")
+    path = transcripts.get(token)
+    if not path or not os.path.exists(path):
+        return render_template("index.html", error="Transcript not found")
+    return send_file(path, as_attachment=True, download_name="transcript.txt")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+python-dotenv
+openai
+moviepy
+pydub

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Transcribe Audio/Video</title>
+</head>
+<body>
+    <h1>Upload Audio or Video for Transcription</h1>
+    <form action="/transcribe" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept=".mp3,.wav,.m4a,.mp4,.mov" required>
+        <button type="submit">Upload and Transcribe</button>
+    </form>
+    <p>Files are processed in 5-minute chunks. Progress will display after upload.</p>
+    {% if error %}
+        <p style="color:red;">{{ error }}</p>
+    {% endif %}
+</body>
+</html>

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Processing...</title>
+</head>
+<body>
+    <h1>Transcribing...</h1>
+    <p>Progress: <span id="percent">0</span>%</p>
+    <script>
+    const task = "{{ task_id }}";
+    async function check() {
+        const resp = await fetch(`/progress?task_id=${task}`);
+        const data = await resp.json();
+        document.getElementById('percent').textContent = data.progress;
+        if (data.status === 'done') {
+            window.location = `/result?task_id=${task}`;
+        } else if (data.status === 'error') {
+            document.body.innerHTML = '<p>Error occurred during transcription.</p>';
+        } else {
+            setTimeout(check, 2000);
+        }
+    }
+    check();
+    </script>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Transcription Result</title>
+</head>
+<body>
+    <h1>Transcription</h1>
+    <pre>{{ transcript }}</pre>
+    <a href="/download?filename={{ filename }}">Download as .txt</a>
+    <br>
+    <a href="/">Transcribe another file</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support large uploads by chunking into five-minute pieces processed with `gpt-4o-transcribe`
- show progress page while background job runs
- log each request and errors
- save transcript for download and update instructions

## Testing
- `python3 -m py_compile app.py`
